### PR TITLE
CI: Add workflow to check for broken links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,13 @@
+name: Check Markdown links
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
Spot any broken links from TSC minutes. Some links can be crucial for referecing importan information that needs to be revisited.

This workflow can be modified to enable "check-modified-files-only" if the team decides to ignore the current broken links.